### PR TITLE
Correct TypeScript Typing for setNotificationListener Callback

### DIFF
--- a/lib/Pushy.d.ts
+++ b/lib/Pushy.d.ts
@@ -37,7 +37,7 @@ declare module 'pushy-react-native' {
      *
      * @param callback This function will be invoked when a new push notification arrives.
      */
-    setNotificationListener(callback: (data: string | object) => void): void;
+    setNotificationListener(callback: (data: string | object) => Promise<void>): void;
 
     /**
      * Set up the notification click listener.


### PR DESCRIPTION
#### Summary:
This pull request addresses a discrepancy in the TypeScript type definition for Pushy's `setNotificationListener` method. The current type definition does not explicitly indicate that the callback function can return a `Promise`, which contradicts the example provided in the [Pushy documentation](https://pushy.me/docs/additional-platforms/react-native) under the "Listen for notifications" section.

```ts
Pushy.setNotificationListener(async data => {
   // implementation
});
```

#### Changes:
- Updated the `Pushy.d.ts` file to reflect that the `setNotificationListener` method's callback argument is an asynchronous function, thereby returning a `Promise`.

#### Justification:
Aligns TypeScript definitions with Pushy documentation, which suggests using an `async` function as the callback, enhancing developer experience and type accuracy.

